### PR TITLE
Fix ref to UTC timezone object from django 3.2

### DIFF
--- a/ddm/tests/test_auth.py
+++ b/ddm/tests/test_auth.py
@@ -128,7 +128,7 @@ class TestAuthCustomTokenAuthenticator(TestCase):
         expired_token = ProjectAccessToken.objects.create(
             project=self.project,
             created=timezone.now(),
-            expiration_date=datetime.datetime(2022, 2, 2, 22, 22).replace(tzinfo=timezone.utc)
+            expiration_date=datetime.datetime(2022, 2, 2, 22, 22).replace(tzinfo=datetime.timezone.utc)
         )
         self.assertRaises(
             exceptions.AuthenticationFailed,


### PR DESCRIPTION
Not sure when django.utils.timezone removed this, but it's not in django 5.1