### PR TITLE
fix ref to old method name removed since django 4.2 assertQuerysetEqual

### DIFF
--- a/ddm/tests/test_admin_views.py
+++ b/ddm/tests/test_admin_views.py
@@ -269,5 +269,5 @@ class TestProjectListView(TestCase):
         response = self.client.get(reverse('project-list'))
         object_list = response.context['object_list']
         expected_queryset = DonationProject.objects.filter(owner__user=self.owner)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             object_list, list(expected_queryset), ordered=False)


### PR DESCRIPTION
https://docs.djangoproject.com/en/5.0/topics/testing/tools/#django.test.TransactionTestCase.assertQuerySetEqual